### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pgiralt/axltoolkit/security/code-scanning/4](https://github.com/pgiralt/axltoolkit/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so every job gets least-privilege token access by default.

Best fix (without changing behavior): add

```yml
permissions:
  contents: read
```

directly under the `on:` trigger section (before `jobs:`). This satisfies CodeQL and preserves existing workflow logic. No new imports, methods, or dependencies are needed, since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
